### PR TITLE
FormatIso8601DateTime null check

### DIFF
--- a/demo/GraphTutorial/Pages/Calendar.razor
+++ b/demo/GraphTutorial/Pages/Calendar.razor
@@ -117,7 +117,7 @@
         // Load into a DateTime
         var dateTime = DateTime.Parse(iso8601DateTime);
 
-        if (dateTime != null)
+        if (!String.IsNullOrWhiteSpace(dateTimeFormat))
         {
             // Format it using the user's settings
             return dateTime.ToString(dateTimeFormat);

--- a/demo/GraphTutorial/Pages/Calendar.razor
+++ b/demo/GraphTutorial/Pages/Calendar.razor
@@ -117,7 +117,7 @@
         // Load into a DateTime
         var dateTime = DateTime.Parse(iso8601DateTime);
 
-        if (!String.IsNullOrWhiteSpace(dateTimeFormat))
+        if (!string.IsNullOrWhiteSpace(dateTimeFormat))
         {
             // Format it using the user's settings
             return dateTime.ToString(dateTimeFormat);


### PR DESCRIPTION
Since DateTime is not nullable, I think checking dateTimeFormat to not be empty is more appropriate here.
(I ran into an error here where dateTimeFormat was empty)